### PR TITLE
XCode8, Beta6 crash

### DIFF
--- a/CascadeClassifierExample/Info.plist
+++ b/CascadeClassifierExample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>To find your face</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Trying to run on a device (from XCode8, Beta6) caused a crash when trying to run on a device, it said that a reason needs to be specified for the use of the camera, so I added one.  That allowed it to run on my test iOS10 device.
